### PR TITLE
Adds message_broker_producer_load_config_options()

### DIFF
--- a/message_broker_producer.admin.inc
+++ b/message_broker_producer.admin.inc
@@ -10,6 +10,8 @@
  */
 function message_broker_producer_config_form($form, &$form_state) {
 
+  $mb_config_settings = $message_broker_producer_load_config_options();
+
   $form['authentication'] = array(
     '#type' => 'fieldset',
     '#title' => t('RabbitMQ Authentication')
@@ -437,4 +439,18 @@ function message_broker_producer_status() {
   $test_links['campaign-reportback-noname'] = 'Generate ' . l('test campaign_reportback_noname producer entry', 'admin/config/services/message-broker-producer/test/campaign_reportback_noname') . '.';
   
   return theme('message_broker_producer_status', array('status' => $status, 'test_links' => $test_links));
+}
+
+
+/**
+ * Load mb_config.json from library and format as PHP object.
+ */
+function message_broker_producer_load_config_options() {
+
+  $mb_config_library = libraries_load('messagebroker-config');
+  $mb_config_path = $GLOBALS['base_url'] . '/' . $mb_config_library['library path'] . '/mb_config.json';
+  $mb_config_json = file_get_contents($mb_config_path);
+  $mb_config_settings = json_decode($mb_config_json);
+
+  return $mb_config_settings;
 }


### PR DESCRIPTION
Fixes #44 

Second attempt...
- Adds hook_libraries_info entry for `messagebroker-config`
- Adds `message_broker_producer_load_config_options()` to load `mb_congif.json` settings
- Stubs out call to `..._load_config_options()` in `message_broker_producer_config_form()`
