### PR TITLE
Add connection and execution timeouts for curl calls.

### DIFF
--- a/message_broker_producer.admin.inc
+++ b/message_broker_producer.admin.inc
@@ -1,5 +1,8 @@
 <?php
 
+define ('MQ_CONNECT_TIMEOUT', 5);
+define ('MQ_EXECUTE_TIMEOUT', 5);
+
 /**
  * @file
  * Content administration and module settings UI.
@@ -84,8 +87,10 @@ function message_broker_producer_status() {
 
   // If the server is down, the smaller of the following two values
   // will kick in first.
-  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);  // Connection timeout in seconds.
-  curl_setopt($ch, CURLOPT_TIMEOUT, 5);  // Function execution timeout in seconds.
+  // CURLOPT_CONNECTTIMEOUT == connection timeout in seconds.
+  // CURLOPT_TIMEOUT == curl function execution timeout in seconds.
+  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, MQ_CONNECT_TIMEOUT);
+  curl_setopt($ch, CURLOPT_TIMEOUT, MQ_EXECUTE_TIMEOUT);
 
   $rabbit_management_api_urls = array(
     'api-aliveness-test' => variable_get('message_broker_producer_rabbitmq_host', 'localhost') .':15672/api/aliveness-test/' . variable_get('message_broker_producer_rabbitmq_vhost', '%2F'),


### PR DESCRIPTION
Set curl options  `CURLOPT_CONNECTTIMEOUT` and `CURLOPT_TIMEOUT` to 5 seconds instead of whatever the defaults are, which feel looooooong.
