### PR TITLE
Issue71-Rename_db_table

### DIFF
--- a/message_broker_producer.admin.inc
+++ b/message_broker_producer.admin.inc
@@ -214,7 +214,7 @@ function message_broker_producer_production_list() {
   $header = array('Production Name', 'Queues', 'Routing Key', 'Status', 'Last Updated');
   $productions = array();
 
-  $query = db_select('message_broker_producer', 'mbp', array('target' => 'slave'))
+  $query = db_select('message_broker_producer_productions', 'mbp', array('target' => 'slave'))
     ->orderBy('machine_name')
     ->fields('mbp');
   $result = $query->execute();
@@ -317,7 +317,7 @@ function message_broker_producer_production_options_form($form, &$form_submit, $
 
     $production_name = $target_production;
     // Lookup production details to display in form while in edit state
-    $query = db_select('message_broker_producer', 'mbp', array('target' => 'slave'))
+    $query = db_select('message_broker_producer_productions', 'mbp', array('target' => 'slave'))
       ->fields('mbp', array('config', 'routing_key', 'status', 'updated'))
       ->condition('mbp.machine_name', $production_name, '=');
     $record = $query->execute()
@@ -534,7 +534,7 @@ function message_broker_producer_production_options_form_submit($form, &$form_st
     $routing_key = check_plain($form_state['values']['message_broker_producer_routing_key']);
     $status = check_plain($form_state['values']['message_broker_producer_status']);
 
-    db_update('message_broker_producer')
+    db_update('message_broker_producer_productions')
       ->fields(array(
         'machine_name' => $production_name,
         'config' => $selected_exchange_config,
@@ -566,7 +566,7 @@ function message_broker_producer_production_options_form_submit($form, &$form_st
     $routing_key = '';
     $status = 0;
 
-    $db_status = db_insert('message_broker_producer')
+    $db_status = db_insert('message_broker_producer_productions')
       ->fields(array(
         'machine_name' => $production_name,
         'config' => $selected_exchange_config,

--- a/message_broker_producer.install
+++ b/message_broker_producer.install
@@ -14,7 +14,7 @@
  */
 function message_broker_producer_schema() {
 
-  $schema['message_broker_producer'] = array(
+  $schema['message_broker_producer_productions'] = array(
     'description' => 'Message Broker Producer production entries. Configuration entries in this table are based on setting found in the mb_config.json file.',
     'fields' => array(
       'machine_name' => array(
@@ -123,7 +123,7 @@ function message_broker_producer_uninstall() {
  */
 function message_broker_producer_enable() {
 
-  drupal_set_message(st('The Message Broker Producer module has been enabled including message_broker_producer database table. Administer the production entries that are referenced in message_broker_producer(<production_name>) in ') .
+  drupal_set_message(st('The Message Broker Producer module has been enabled including message_broker_producer_productions database table. Administer the production entries and RabbitMQ connections settings in ') .
       ' ' . l(st('Account Settings'), 'admin/config/services/message-broker-producer/production-options') . '.',
     'status');
 }
@@ -175,7 +175,7 @@ function message_broker_producer_update_7002(&$sandbox) {
 
   // Define schema to allow upgrade path as hook_schema
   // may change in future versions.
-  $schema['message_broker_producer'] = array(
+  $schema['message_broker_producer_productions'] = array(
     'description' => 'Message Broker Producer production entries. Configuration entries in this table are based on setting found in the mb_config.json file.',
     'fields' => array(
       'machine_name' => array(
@@ -217,5 +217,5 @@ function message_broker_producer_update_7002(&$sandbox) {
     'primary key' => array('machine_name'),
   );
 
-  db_create_table('message_broker_producer', $schema['message_broker_producer']);
+  db_create_table('message_broker_producer_productions', $schema['message_broker_producer_productions']);
 }


### PR DESCRIPTION
Fixes #71 
- Renames `message_broker_producer` databases table to `message_broker_producer_productions`. To provide a more descriptive table name and to make way for additional tables in the future.
