### PR TITLE
Adds binding_patterns support

### DIFF
--- a/message_broker_producer.info
+++ b/message_broker_producer.info
@@ -1,6 +1,6 @@
 name = "Message Broker Producer"
 description = "Provides producer access to for a Drupal site to a Message Broker (RabbitMQ) system."
-version = 0.2.04
+version = 0.2.05
 core = 7.x
 
 dependencies[] = libraries

--- a/message_broker_producer.module
+++ b/message_broker_producer.module
@@ -224,16 +224,19 @@ function message_broker_producer_request($production = '', $param = array()) {
         );
 
         foreach ($production_settings->queues as $production_queue => $queue) {
+          foreach ($queue->binding_patterns as $binding_count => $binding_pattern) {
 
-          $config['queue'][$production_queue] = array(
-            'name' => $production_queue,
-            'passive' => $queue->passive,
-            'durable' => $queue->durable,
-            'exclusive' => $queue->exclusive,
-            'auto_delete' => $queue->auto_delete,
-            'bindingKey' => $queue->binding_pattern,
-          );
+            $production_queue_id = $production_queue . '-' . $binding_count;
+            $config['queue'][$production_queue_id] = array(
+              'name' => $production_queue,
+              'passive' => $queue->passive,
+              'durable' => $queue->durable,
+              'exclusive' => $queue->exclusive,
+              'auto_delete' => $queue->auto_delete,
+              'bindingKey' => $binding_pattern,
+            );
 
+          }
         }
 
         try {


### PR DESCRIPTION
With the introduction of multiple binding patterns on the `mobileCommonsQueue` rather than the original one binding per queue definition. This PR adds support for defining queue entries as needed based on the number of bindings detected.

Fixes #94
Resolves issue allowing https://github.com/DoSomething/mbc-registration-email/pull/47 to be tested.