### PR TITLE
Fixes an issue with missing library in status report.

### DIFF
--- a/message_broker_producer.install
+++ b/message_broker_producer.install
@@ -68,8 +68,7 @@ function message_broker_producer_requirements($phase) {
 
   if ($phase == 'runtime') {
 
-    $phplib_library = libraries_detect('messagebroker-phplib');
-    $config_library = libraries_detect('messagebroker-config');
+    $library = libraries_detect('messagebroker-phplib');
 
     // Get name of appropriate localization function.
     $t = get_t();


### PR DESCRIPTION
Closes #1.

It turned out that it's just an issue with wrong variable name.
`libraries_detect()` result saved to `$phplib_library` but `$library` checked for the results below.

- Fixes `libraries_detect()` result variable
- Removes unused `$config_library`